### PR TITLE
Removed new parameters RA and Dec from the identifier for timeviz

### DIFF
--- a/esasky-cl/src/main/java/esac/archive/esasky/cl/web/client/view/resultspanel/TimeSeriesPanel.java
+++ b/esasky-cl/src/main/java/esac/archive/esasky/cl/web/client/view/resultspanel/TimeSeriesPanel.java
@@ -85,16 +85,18 @@ public class TimeSeriesPanel extends MovableResizablePanel<TimeSeriesPanel> {
     
     public static TimeSeriesPanel toggleTimeSeriesData(String mission, String dataId, String secondIdentifier, String ra, String dec) {
     	TimeSeriesPanel timeSeriesPanel = getTimeSeriesPanel(mission);
-        String[] dataInfo = {mission, dataId, secondIdentifier, ra, dec};
-        if (timeSeriesPanel.currentData.contains(String.join(",", dataInfo))) {
-        	timeSeriesPanel.currentData.remove(String.join(",", dataInfo));
-        	timeSeriesPanel.removeData(dataInfo);
+        // To preserve sessions created in 7.3.1 or earlier, the new parameters RA and Dec are not used in the data identifier
+        String[] dataIdentifier = {mission, dataId, secondIdentifier};
+        if (timeSeriesPanel.currentData.contains(String.join(",", dataIdentifier))) {
+        	timeSeriesPanel.currentData.remove(String.join(",", dataIdentifier));
+        	timeSeriesPanel.removeData(dataIdentifier);
             if (timeSeriesPanel.currentData.isEmpty()) {
             	timeSeriesPanel.hide();
             }
         } else {
-        	timeSeriesPanel.currentData.add(String.join(",", dataInfo));
-        	timeSeriesPanel.addData(dataInfo);
+        	timeSeriesPanel.currentData.add(String.join(",", dataIdentifier));
+            String [] dataToAdd = {mission, dataId, secondIdentifier, ra, dec};
+            timeSeriesPanel.addData(dataToAdd);
         }
         return timeSeriesPanel;
     }

--- a/esasky-cl/src/main/java/esac/archive/esasky/cl/web/client/view/resultspanel/TimeSeriesPanel.java
+++ b/esasky-cl/src/main/java/esac/archive/esasky/cl/web/client/view/resultspanel/TimeSeriesPanel.java
@@ -84,17 +84,17 @@ public class TimeSeriesPanel extends MovableResizablePanel<TimeSeriesPanel> {
     }
     
     public static TimeSeriesPanel toggleTimeSeriesData(String mission, String dataId, String secondIdentifier, String ra, String dec) {
-    	TimeSeriesPanel timeSeriesPanel = getTimeSeriesPanel(mission);
+        TimeSeriesPanel timeSeriesPanel = getTimeSeriesPanel(mission);
         // To preserve sessions created in 7.3.1 or earlier, the new parameters RA and Dec are not used in the data identifier
         String[] dataIdentifier = {mission, dataId, secondIdentifier};
         if (timeSeriesPanel.currentData.contains(String.join(",", dataIdentifier))) {
-        	timeSeriesPanel.currentData.remove(String.join(",", dataIdentifier));
-        	timeSeriesPanel.removeData(dataIdentifier);
+            timeSeriesPanel.currentData.remove(String.join(",", dataIdentifier));
+            timeSeriesPanel.removeData(dataIdentifier);
             if (timeSeriesPanel.currentData.isEmpty()) {
-            	timeSeriesPanel.hide();
+                timeSeriesPanel.hide();
             }
         } else {
-        	timeSeriesPanel.currentData.add(String.join(",", dataIdentifier));
+            timeSeriesPanel.currentData.add(String.join(",", dataIdentifier));
             String [] dataToAdd = {mission, dataId, secondIdentifier, ra, dec};
             timeSeriesPanel.addData(dataToAdd);
         }


### PR DESCRIPTION
To preserve sessions created in 7.3.1 or earlier, the new parameters RA and Dec are not used in the data identifier for timeviz